### PR TITLE
Add safecopy migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+0.3.0.0
+=======
+
+* Support for `safecopy` for migrations.
+
+0.2.0.0
+=======
+
+* Changelog is added.

--- a/blobster.cabal
+++ b/blobster.cabal
@@ -50,7 +50,9 @@ test-suite blobster-test
   default-language:    Haskell2010
   default-extensions:
     OverloadedStrings
+    RecordWildCards
     TemplateHaskell
+    TypeFamilies
 
 source-repository head
   type:     git

--- a/blobster.cabal
+++ b/blobster.cabal
@@ -5,8 +5,8 @@ description:         Please see README.md
 homepage:            https://github.com/githubuser/blobster#readme
 license:             BSD3
 license-file:        LICENSE
-author:              Dmitry Zuikov 
-maintainer:          dzuikov@gmil.com 
+author:              Dmitry Zuikov
+maintainer:          dzuikov@gmil.com
 copyright:           2017 Dmitry Zuikov
 category:            Data
 build-type:          Simple
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Data.Blobster 
+  exposed-modules:     Data.Blobster
   build-depends:       base >= 4.7 && < 5
                      , base16-bytestring
                      , bytestring
@@ -24,11 +24,13 @@ library
                      , directory
                      , filepath
                      , memory
+                     , safecopy            >= 0.9 && < 0.10
 
   default-language:    Haskell2010
 
   default-extensions:
     OverloadedStrings
+    TemplateHaskell
 
 test-suite blobster-test
   type:                exitcode-stdio-1.0
@@ -51,4 +53,3 @@ test-suite blobster-test
 source-repository head
   type:     git
   location: https://github.com/voidlizard/blobster
-

--- a/blobster.cabal
+++ b/blobster.cabal
@@ -1,30 +1,31 @@
 name:                blobster
-version:             0.2.0.0
-synopsis:            Initial project template from stack
+version:             0.3.0.0
+synopsis:            Simple storage of objects as blobs in files.
 description:         Please see README.md
-homepage:            https://github.com/githubuser/blobster#readme
+homepage:            https://github.com/voidlizard/blobster#readme
 license:             BSD3
 license-file:        LICENSE
-author:              Dmitry Zuikov
+author:              Dmitry Zuikov, Anton Gushcha
 maintainer:          dzuikov@gmil.com
 copyright:           2017 Dmitry Zuikov
 category:            Data
 build-type:          Simple
 extra-source-files:  README.md
+                     CHANGELOG.md
 cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
   exposed-modules:     Data.Blobster
-  build-depends:       base >= 4.7 && < 5
-                     , base16-bytestring
-                     , bytestring
-                     , cereal
-                     , cryptonite
-                     , directory
-                     , filepath
-                     , memory
-                     , safecopy            >= 0.9 && < 0.10
+  build-depends:       base                >= 4.7  && < 5
+                     , base16-bytestring   >= 0.1  && < 0.2
+                     , bytestring          >= 0.10 && < 0.11
+                     , cereal              >= 0.5  && < 0.6
+                     , cryptonite          >= 0.21 && < 0.22
+                     , directory           >= 1.2  && < 1.4
+                     , filepath            >= 1.4  && < 1.5
+                     , memory              >= 0.13 && < 0.15
+                     , safecopy            >= 0.9  && < 0.10
 
   default-language:    Haskell2010
 

--- a/blobster.cabal
+++ b/blobster.cabal
@@ -43,12 +43,14 @@ test-suite blobster-test
                      , cereal
                      , hspec
                      , QuickCheck
+                     , safecopy
                      , temporary
 
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   default-extensions:
     OverloadedStrings
+    TemplateHaskell
 
 source-repository head
   type:     git

--- a/src/Data/Blobster.hs
+++ b/src/Data/Blobster.hs
@@ -14,6 +14,7 @@ import Crypto.Hash
 import Data.ByteString (ByteString)
 import Data.List (splitAt)
 import Data.Maybe
+import Data.SafeCopy
 import Data.Serialize (Serialize)
 import GHC.Generics
 import System.Directory
@@ -25,6 +26,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.Serialize as S
+import qualified Data.Serialize.Get as S
+import qualified Data.Serialize.Put as S
 
 class InnerPath a where
   innerPath :: a -> (FilePath, FilePath)
@@ -36,11 +39,15 @@ newtype ObjectID = ObjectID { objectID :: ByteString }
                    deriving (Eq,Ord,Generic)
 
 newtype ObjectRef = ObjectRef BlobID
-                    deriving (Show,Eq,Ord,Generic)
+                    deriving (Eq,Ord,Generic)
 
 instance Serialize BlobID
 instance Serialize ObjectID
 instance Serialize ObjectRef
+
+deriveSafeCopy 1 'base ''BlobID
+deriveSafeCopy 1 'base ''ObjectID
+deriveSafeCopy 1 'base ''ObjectRef
 
 instance Show BlobID where
   show bid = mconcat ["BlobID ", "\"", p, ps, "\""]
@@ -50,6 +57,10 @@ instance Show ObjectID where
   show oid = mconcat ["ObjectID ", "\"", p, ps, "\""]
     where (p,ps) = innerPath oid
 
+instance Show ObjectRef where
+  show oid = mconcat ["ObjectRef ", "\"", p, ps, "\""]
+    where (p,ps) = innerPath oid
+
 instance InnerPath BlobID where
   innerPath (BlobID b) = splitAt 2 b16
     where b16 = BS8.unpack (Base16.encode b)
@@ -57,6 +68,9 @@ instance InnerPath BlobID where
 instance InnerPath ObjectID where
   innerPath (ObjectID b) = splitAt 2 b16
     where b16 = BS8.unpack (Base16.encode b)
+
+instance InnerPath ObjectRef where
+  innerPath (ObjectRef b) = innerPath b
 
 data Blobster = Blobster { prefixPath :: FilePath
                          , prefixBlob :: FilePath
@@ -76,29 +90,29 @@ makeDir pref = do
   createDirectoryIfMissing True (prefixRef conf)
   return conf
 
-putObject :: Serialize a => Blobster -> ObjectID -> a -> IO BlobID
+putObject :: SafeCopy a => Blobster -> ObjectID -> a -> IO BlobID
 putObject cfg oid o = do
   -- FIXME: exception handling
   bid <- putBlob cfg o
   _   <- putBlob' cfg True (prefixRef cfg) oid (S.encode (ObjectRef bid))
   return bid
 
-getObject :: Serialize a => Blobster -> ObjectID -> IO (Either String a)
+getObject :: SafeCopy a => Blobster -> ObjectID -> IO (Either String a)
 getObject cfg oid = do
   oref <- getBlob' cfg (prefixRef cfg) oid :: IO (Either String ObjectRef)
   case oref of
     Left s -> return $ Left s
     Right (ObjectRef bid) -> getBlob cfg bid
 
-putBlob :: Serialize a => Blobster -> a -> IO BlobID
+putBlob :: SafeCopy a => Blobster -> a -> IO BlobID
 putBlob cfg x = do
-  let blob = S.encode x
+  let blob = S.runPut $ safePut x
   let blobid = makeBlobID blob
   putBlob' cfg False (prefixBlob cfg) blobid blob
   return blobid
 
-getBlob :: Serialize a => Blobster -> BlobID -> IO (Either String a)
-getBlob cfg bid = getBlob' cfg (prefixBlob cfg) bid
+getBlob :: SafeCopy a => Blobster -> BlobID -> IO (Either String a)
+getBlob cfg = getBlob' cfg (prefixBlob cfg)
 
 xferBlob :: InnerPath a => Bool -> Blobster -> Blobster -> a -> IO ()
 xferBlob ow db1 db2 bid = do
@@ -118,7 +132,7 @@ blobPath :: InnerPath a => Blobster -> FilePath -> a -> FilePath
 blobPath cfg pref bid = pref </> pp </> fname
   where (pp,fname) = innerPath bid
 
-getBlob' :: (Serialize a, InnerPath oid)
+getBlob' :: (SafeCopy a, InnerPath oid)
          => Blobster
          -> FilePath
          -> oid
@@ -127,9 +141,9 @@ getBlob' :: (Serialize a, InnerPath oid)
 getBlob' cfg p oid = do
   let path = blobPath cfg p oid
   ex <- doesFileExist path
-  case ex of
-    False -> return (Left (mconcat ["not exists: ", path] ))
-    True  -> BS.readFile path >>= return . S.decode
+  if ex
+    then return (Left (mconcat ["not exists: ", path] ))
+    else S.runGet safeGet <$> BS.readFile path
 
 putBlob' :: InnerPath oid
          => Blobster
@@ -157,4 +171,3 @@ makeBlobID bs = BlobID (hashKey bs)
 hashKey :: ByteString -> ByteString
 hashKey bs = bytes
   where bytes = BS.pack (BA.unpack (hash bs :: Digest SHA1))
-

--- a/test/Data/Blobster/BasicSpec.hs
+++ b/test/Data/Blobster/BasicSpec.hs
@@ -8,6 +8,7 @@ import Data.Blobster
 import Control.Exception
 import Control.Monad
 import Data.ByteString (ByteString)
+import Data.SafeCopy
 import Data.Serialize
 import Data.String
 import GHC.Generics
@@ -28,9 +29,8 @@ data CustomDataExample = CustomDataExample { name :: String
                                            , someEnum :: [CustomEnum]
                                            } deriving (Show,Eq,Ord,Generic)
 
-
-instance Serialize CustomDataExample
-instance Serialize CustomEnum
+deriveSafeCopy 1 'base ''CustomDataExample
+deriveSafeCopy 1 'base ''CustomEnum
 
 instance Arbitrary ObjectID where
   arbitrary = makeObjectID <$> (BS.pack <$> arbitrary)
@@ -49,61 +49,55 @@ withTempDb  fn =
 
 spec :: Spec
 spec = around withTempDb $ do
-
-  describe "basic-1" $ do
+  describe "basic" $ do
     it "Writes/reads a number to blobster" $ \db -> do
       bid <- putBlob db (1 :: Int)
       n <- getBlob db bid :: IO (Either String Int)
-      n `shouldBe` (Right 1)
+      n `shouldBe` Right 1
 
-  describe "basic-2" $ do
-      it "Writes/reads a lots of numbers to blobster" $ \db -> do
-        replicateM_ 1000 $ do
-              ints <- generate arbitrary :: IO [Int]
-              bids <- mapM (putBlob db) ints
-              eints <- mapM (getBlob db) bids
-              (fmap Right ints)  `shouldBe` eints
+    it "Writes/reads a lots of numbers to blobster" $ \db -> do
+      replicateM_ 1000 $ do
+        ints <- generate arbitrary :: IO [Int]
+        bids <- mapM (putBlob db) ints
+        eints <- mapM (getBlob db) bids
+        eints `shouldBe` fmap Right ints
 
-  describe "basic-3" $ do
-      it "Writes/reads a lots of complex objects" $ \db -> do
-        replicateM_ 1000 $ do
-              c <- generate arbitrary :: IO CustomDataExample
-              bid <- putBlob db c
-              c1 <- getBlob db bid
-              c1 `shouldBe` (Right c)
+    it "Writes/reads a lots of complex objects" $ \db -> do
+      replicateM_ 1000 $ do
+        c <- generate arbitrary :: IO CustomDataExample
+        bid <- putBlob db c
+        c1 <- getBlob db bid
+        c1 `shouldBe` Right c
 
-  describe "basic-4" $ do
-      it "Writes/reads a single indexed object" $ \db -> do
+    it "Writes/reads a single indexed object" $ \db -> do
+      oid <- generate arbitrary :: IO ObjectID
+      o <- generate arbitrary :: IO CustomDataExample
+      putObject db oid o
+      o' <- getObject db oid :: IO (Either String CustomDataExample)
+      o' `shouldBe` Right o
+
+    it "Writes/reads a lot of indexed objects" $ \db -> do
+      replicateM_ 100 $ do
         oid <- generate arbitrary :: IO ObjectID
         o <- generate arbitrary :: IO CustomDataExample
         putObject db oid o
         o' <- getObject db oid :: IO (Either String CustomDataExample)
-        o' `shouldBe` (Right o)
+        o' `shouldBe` Right o
 
-  describe "basic-5" $ do
-      it "Writes/reads a lot of indexed objects" $ \db -> do
-        replicateM_ 100 $ do
-          oid <- generate arbitrary :: IO ObjectID
-          o <- generate arbitrary :: IO CustomDataExample
-          putObject db oid o
-          o' <- getObject db oid :: IO (Either String CustomDataExample)
-          o' `shouldBe` (Right o)
+    it "Creates objects in the first db and moves them to the new db" $ \db -> do
+      a <- replicateM 1000 $ do
+        c <- generate arbitrary :: IO CustomDataExample
+        bid <- putBlob db c
+        return (bid,c)
 
-  describe "basic-5" $ do
-      it "Creates objects in the first db and moves them to the new db" $ \db -> do
-        a <- replicateM 1000 $ do
-          c <- generate arbitrary :: IO CustomDataExample
-          bid <- putBlob db c
-          return (bid,c)
+      withTempDb $ \db1 -> do
+        forM_ a $ \(b,_) -> do
+          xferBlob False db db1 b
 
-        withTempDb $ \db1 -> do
-          forM_ a $ \(b,_) -> do
-            xferBlob False db db1 b
+        o2 <- mapM (getBlob db1 . fst) a
+        let o1 = fmap (Right . snd) a
 
-          o2 <- mapM (getBlob db1 . fst) a
-          let o1 = fmap (Right . snd) a
-
-          o2 `shouldBe` o1
+        o2 `shouldBe` o1
 
 
 main :: IO ()


### PR DESCRIPTION
Fixes the https://github.com/hexresearch/aol-web-frontpage/issues/17

* Use `SafeCopy` type class instead of `Serialize`.

* Migration tests that cover the three use cases:
     - Migration from an initial format to a new one.
     - Migration from a extended format to a new one.
     - Transitive migration from base format to the most recent one.

How to test:

* Check the changes of API.

* Check that tests are passed successfully.

Two other repos are updated: https://github.com/NCrashed/tourseek and https://github.com/NCrashed/aol-web-frontpage. `rol-export` doesn't require changes.

I will open PRs for the updated repos as soon as the PR is merged, as `stack.yaml` files should be updated to point to new master of blobster.